### PR TITLE
Fix for Foundry installs with non-root routePrefix

### DIFF
--- a/scripts/wjmais.js
+++ b/scripts/wjmais.js
@@ -1,4 +1,4 @@
-import { DND5E } from "/systems/dnd5e/module/config.js";
+import { DND5E } from "../../../systems/dnd5e/module/config.js";
 import { WJMAIS } from "./config.js";
 import { applyPatches } from "./patch.js";
 import { updateActorEffects } from "./effects.js";


### PR DESCRIPTION
This is an issue if you have a web server that reverse proxies a Foundry instance from http://example.foo/ to http://example.foo/vtt or similar.